### PR TITLE
Fix array methods for model drop

### DIFF
--- a/lib/solid/model_drop.rb
+++ b/lib/solid/model_drop.rb
@@ -87,7 +87,8 @@ class Solid::ModelDrop < Liquid::Drop
     raise NoMethodError.new("undefined method `#{method_name}' for #{self.inspect}")
   end
 
-  delegate *(Array.public_instance_methods - self.public_instance_methods), :to => :scope
+  delegate :to_a, to: :each
+  delegate *(Array.public_instance_methods - self.public_instance_methods), to: :to_a
 
   protected
 

--- a/spec/solid/model_drop_spec.rb
+++ b/spec/solid/model_drop_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'active_support/core_ext'
+require 'ostruct'
+Rails = OpenStruct.new(env: OpenStruct.new(test?: true))
+require 'solid/model_drop'
+
+describe Solid::ModelDrop do
+  describe "array methods" do
+
+    it "work on a drop" do
+      drop = described_class.new([1, 2, 3])
+      drop.reverse.should be == [3, 2, 1]
+    end
+
+  end
+end

--- a/spec/solid/model_drop_spec.rb
+++ b/spec/solid/model_drop_spec.rb
@@ -12,5 +12,15 @@ describe Solid::ModelDrop do
       drop.reverse.should be == [3, 2, 1]
     end
 
+    it "go through #each" do
+      klass = Class.new(described_class) do
+        def each
+          super.select(&:odd?)
+        end
+      end
+      drop = klass.new([1, 2, 3])
+      drop.reverse.should be == [3, 1]
+    end
+
   end
 end


### PR DESCRIPTION
I had a bug because a descendant class of `Solid::ModelDrop` was overriding `#each`, but calling `reverse` or any other method on an instance didn't go through `#each`.
