### PR TITLE
Without a `else` block, a ConditionalBlock will always execute the first block

### DIFF
--- a/lib/solid/conditional_block.rb
+++ b/lib/solid/conditional_block.rb
@@ -10,8 +10,8 @@ class Solid::ConditionalBlock < Liquid::Block
   def render(context)
     with_context(context) do
       display(*arguments.interpolate(context)) do |condition_satisfied|
-        block = condition_satisfied ? @blocks.first : @blocks.last
-        render_all(block, context)
+        block = condition_satisfied ? @blocks.first : @blocks[1]
+        render_all(block, context) if block
       end
     end
   end

--- a/spec/solid/conditional_block_spec.rb
+++ b/spec/solid/conditional_block_spec.rb
@@ -28,6 +28,12 @@ describe Solid::ConditionalBlock do
       subject.render(context).should be == 'blank'
     end
 
+    it 'yielding false without a `else` block does not render anything' do
+      context = Liquid::Context.new('mystring' => '')
+      subject = IfPresent.new('ifpresent', 'mystring', ['present', '{% endifpresent %}'])
+      subject.render(context).should be_nil
+    end
+
   end
 
 end


### PR DESCRIPTION
I think it comes from the fact that we take the last block, which is also the first when there's no `else` block.
https://github.com/tigerlily/solid/blob/96c98f512b8b1c67daa724db4644f05f674c038e/lib/solid/conditional_block.rb#L13
