### PR TITLE
Respect Liquid convention of calling #context=

### DIFF
--- a/lib/solid.rb
+++ b/lib/solid.rb
@@ -35,6 +35,12 @@ module Solid
       object
     end
 
+    def to_liquid(object, context)
+      object = object.to_liquid
+      object.context = context if object.respond_to?(:context=)
+      object
+    end
+
   end
 
   SyntaxError = Class.new(Liquid::SyntaxError)

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -5,13 +5,13 @@ class Solid::Parser
 
   class ContextVariable < Struct.new(:name)
     def evaluate(context)
-      context[name].to_liquid
+      Solid.to_liquid(context[name], context)
     end
   end
 
   class Literal < Struct.new(:value)
     def evaluate(context)
-      value.to_liquid
+      Solid.to_liquid(value, context)
     end
   end
 
@@ -41,7 +41,7 @@ class Solid::Parser
     }
 
     def evaluate(context)
-      pluck(receiver.evaluate(context), name, *arguments.map {|arg| arg.evaluate(context) }).to_liquid
+      Solid.to_liquid(pluck(receiver.evaluate(context), name, *arguments.map {|arg| arg.evaluate(context) }), context)
     end
 
     protected

--- a/spec/solid/arguments_spec.rb
+++ b/spec/solid/arguments_spec.rb
@@ -258,6 +258,30 @@ describe Solid::Arguments do
       }.to raise_error(Solid::SyntaxError)
     end
 
+    it "should use #to_liquid" do
+      drop = Object.new
+      def drop.to_liquid
+        'liquid'
+      end
+      parse('drop', 'drop' => drop).should be == ['liquid']
+    end
+
+    it "should use #context= if available" do
+      drop = Object.new
+      class << drop
+        def to_liquid
+          self
+        end
+        def to_s
+          @alias
+        end
+        def context=(context)
+          @alias = context['alias']
+        end
+      end
+      parse('drop.to_s', 'drop' => drop, 'alias' => 'liquid').should be == ['liquid']
+    end
+
   end
 
   context 'with useless round brackets' do


### PR DESCRIPTION
On a unknown object, we call `#to_liquid` to make sure it's safe, then we should call `#context=` (if available) to pass it the current context, like it's done in `Liquid::Context#find_variable`.
