### PR TITLE
Add support for parsing using ruby_parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
   - rbx-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
   - rbx-19mode
-matrix:
-  allow_failures:
-    - rvm: rbx-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rvm:
   - 2.0.0
   - jruby-19mode
   - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: jruby-19mode
+    - rvm: rbx-19mode

--- a/lib/solid/arguments.rb
+++ b/lib/solid/arguments.rb
@@ -1,5 +1,3 @@
-require 'ripper'
-
 class Solid::Arguments
   include Enumerable
 

--- a/lib/solid/default_security_rules.rb
+++ b/lib/solid/default_security_rules.rb
@@ -6,7 +6,7 @@ Solid::MethodWhitelist
     Module => [:==],
     Enumerable => [:sort],
     Comparable => [:<, :<=, :==, :>, :>=, :between?],
-    Numeric => [:blank?,
+    Numeric => [:blank?, :+@,
       :second, :seconds, :minute, :minutes, :hour, :hours, :day, :days, :week, :weeks,
       :bytes, :kilobytes, :megabytes, :gigabytes, :terabytes, :petabytes, :exabytes],
     Integer => [:multiple_of?, :month, :months, :year, :years, :to_json],

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -7,7 +7,11 @@ class Solid::Parser
     autoload :Ripper, File.join(BASE_PATH, 'ripper')
   rescue LoadError
   end
-  autoload :RubyParser, File.join(BASE_PATH, 'ruby_parser')
+  begin
+    require 'ruby_parser'
+    autoload :RubyParser, File.join(BASE_PATH, 'ruby_parser')
+  rescue LoadError
+  end
 
   class ContextVariable < Struct.new(:name)
     def evaluate(context)
@@ -82,7 +86,17 @@ class Solid::Parser
     attr_writer :parser
 
     def parser
-      @parser || Solid::Parser::RubyParser
+      @parser || begin
+        if defined?(Solid::Parser::RubyParser)
+          Solid::Parser::RubyParser
+        elsif defined?(Solid::Parser::Ripper)
+          Solid::Parser::Ripper
+        else
+          raise "You need to run MRI (to have Ripper), "\
+            "or have 'ruby_parser' in $LOAD_PATH "\
+            "or set #{self}.parser yourself"
+        end
+      end
     end
 
     def parse(string)

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -39,7 +39,9 @@ class Solid::Parser
     include Solid::MethodWhitelist
     BUILTIN_HANDLERS = {
       :'&&' => ->(left, right) { left && right },
-      :'||' => ->(left, right) { left || right }
+      :'||' => ->(left, right) { left || right },
+      :'and' => ->(left, right) { left and right },
+      :'or' => ->(left, right) { left or right }
     }
 
     def evaluate(context)

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -2,7 +2,11 @@ class Solid::Parser
 
   BASE_PATH = File.join(File.expand_path(File.dirname(__FILE__)), 'parser')
 
-  autoload :Ripper, File.join(BASE_PATH, 'ripper')
+  begin
+    require 'ripper'
+    autoload :Ripper, File.join(BASE_PATH, 'ripper')
+  rescue LoadError
+  end
   autoload :RubyParser, File.join(BASE_PATH, 'ruby_parser')
 
   class ContextVariable < Struct.new(:name)

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -1,7 +1,8 @@
-require 'set'
-require 'ripper'
-
 class Solid::Parser
+
+  BASE_PATH = File.join(File.expand_path(File.dirname(__FILE__)), 'parser')
+
+  autoload :Ripper, File.join(BASE_PATH, 'ripper')
 
   class ContextVariable < Struct.new(:name)
     def evaluate(context)
@@ -60,206 +61,24 @@ class Solid::Parser
 
   end
 
-  class << self
-
-    def parse(string)
-      new(string).parse
-    end
-
-  end
-
-  def initialize(string)
-    @string = string
-    @sexp = nil
-  end
-
-  def parse
-    @sexp = Ripper.sexp(@string)
-    dive_in or raise 'Ripper changed?'
-    parse_one(@sexp)
-  end
-
-  # Looks for a structure like
-  # [:program, [[:array, [#stuff#]]]] or
-  # [:program, [[:array, nil]]]
-  def dive_in
-    @sexp = @sexp[1]
-    @sexp = @sexp.first
-  end
-
-  def parse_one(argument)
-    type = argument.shift
-    handler = "handle_#{type.to_s.sub('@', '')}"
-    raise Solid::SyntaxError, "unknown Ripper type: #{type.inspect}" unless respond_to?(handler)
-    public_send handler, *argument
-  end
-
-  # # spam
-  # [:@ident, "spam", [1, 33]] or
-  # # true
-  # [:@kw, "true", [1, 23]]
-  def handle_var_ref(var_ref)
-    parse_one(var_ref)
-  end
-
-  # # foo: 42
-  # [[:assoc_new, [:@label, "foo:", [1, 1]], [:@int, "42", [1, 5]]]]
-  def handle_bare_assoc_hash(assoc_hash)
-    LiteralHash.new assoc_hash.map {|(_, *key_value)| key_value.map(&method(:parse_one)) }
-  end
-
-  # # {foo: 42}
-  # [:assoclist_from_args, [[:assoc_new, [:@label, "foo:", [1, 2]], [:@int, "42", [1, 7]]]]]
-  def handle_hash(hash)
-    handle_bare_assoc_hash(hash.last)
-  end
-
-  # # myvar.length
-  #
-  # [:var_ref, [:@ident, "myvar", [1, 1]]]
-  # :"."
-  # [:@ident, "length", [1, 7]]
-  def handle_call(receiver_sexp, method_call, method_sexp)
-    receiver = parse_one(receiver_sexp)
-    method = method_sexp[1]
-    MethodCall.new receiver, method, []
-  end
-
-  # # myvar
-  #
-  # since 1.9.3
-  # [:vcall, [:@ident, "myvar", [1, 0]]]
-  def handle_vcall(expression)
-    parse_one(expression)
-  end
-
-  # # myvar.split(',', 2)
-  #
-  # [:call, [:var_ref, [:@ident, "myvar", [1, 1]]], :".", [:@ident, "split", [1, 7]]]
-  # [:arg_paren, [:args_add_block, [
-  #     [:string_literal, [:string_content, [:@tstring_content, ",", [1, 14]]]],
-  #     [:@int, "2", [1, 18]]
-  #   ], false]]
-  def handle_method_add_arg(call_sexp, args_sexp)
-    method_call = parse_one(call_sexp)
-    method_call.arguments = method_call_args(args_sexp)
-    method_call
-  end
-
-  # # args list: (',', 2)
-  # [:arg_paren, [:args_add_block, [
-  #     [:string_literal, [:string_content, [:@tstring_content, ",", [1, 14]]]],
-  #     [:@int, "2", [1, 18]]
-  #   ], false]]
-  #
-  # 1 args list: ()
-  # [:arg_paren, nil]
-  def method_call_args(args_sexp)
-    return [] if args_sexp[1].nil?
-    args_sexp = args_sexp.last[1]
-    args_sexp.map(&method(:parse_one))
-  end
-
-  # # !true
-  # [:!, [:var_ref, [:@kw, "true", [1, 1]]]]
-  def handle_unary(operator, operand)
-    MethodCall.new(parse_one(operand), operator, [])
-  end
-
-  # # 1 + 2
-  # [:@int, "1", [1, 0]], :*, [:@int, "2", [1, 4]]
-  def handle_binary(left_operand, operator, right_operand)
-    receiver = parse_one(left_operand)
-    MethodCall.new(receiver, operator, [parse_one(right_operand)])
-  end
-
-  # # [1]
-  # [[:@int, "1", [1, 1]]
-  def handle_array(array)
-    LiteralArray.new((array || []).map(&method(:parse_one)))
-  end
-
-  # # (1)
-  # [[:@int, "42", [1, 2]]]
-  def handle_paren(content)
-    parse_one(content.first)
-  end
-
-  # # 1..10
-  # [[:@int, "1", [1, 0]], [:@int, "10", [1, 4]]]
-  def handle_dot2(start_value, end_value)
-    LiteralRange.new(parse_one(start_value), parse_one(end_value), false)
-  end
-
-  # # 1...10
-  # [[:@int, "1", [1, 0]], [:@int, "10", [1, 4]]]
-  def handle_dot3(start_value, end_value)
-    LiteralRange.new(parse_one(start_value), parse_one(end_value), true)
-  end
-
-  # # 'mystring'
-  # [:string_content, [:@tstring_content, "mystring", [1, 14]]]
-  # TODO: handle string interpolation
-  def handle_string_literal(string_content)
-    Literal.new(parse_one(string_content))
-  end
-
-  def handle_string_content(*parts)
-    parts.map(&method(:parse_one)).join
-  end
-
-  # [:@tstring_content, "mystring", [1, 14]]
-  def handle_tstring_content(string_content, lineno_column)
-    string_content
-  end
-
-  # # /bb|[^b]{2}/
-  # [[:@tstring_content, "bb|[^b]{2}", [1, 2]]].first.first
-  # TODO: handle regexp interpolation
-  def handle_regexp_literal(regexp_literal, lineno_column)
-    Literal.new Regexp.new(regexp_literal.first[1])
-  end
-
   KEYWORDS = {
     'true' => Literal.new(true),
     'false' => Literal.new(false),
     'nil' => Literal.new(nil),
   }
-  # # true
-  # "true", [1, 33]
-  def handle_kw(keyword, lineno_column)
-    raise Solid::SyntaxError, 'unknown Ripper sexp' unless KEYWORDS.has_key? keyword
-    KEYWORDS[keyword]
-  end
 
-  # # spam
-  # "spam", [1, 23]
-  def handle_ident(identifier, lineno_column)
-    ContextVariable.new identifier
-  end
+  class << self
 
-  # # Spam
-  # "Spam", [1, 23]
-  def handle_const(constant, lineno_column)
-    ContextVariable.new constant
-  end
+    attr_writer :parser
 
-  # # 42
-  # "42", [1, 2]
-  def handle_int(int, lineno_column)
-    Literal.new int.to_i
-  end
+    def parser
+      @parser || Solid::Parser::Ripper
+    end
 
-  # # 4.2
-  # "4.2", [1, 2]
-  def handle_float(float, lineno_column)
-    Literal.new float.to_f
-  end
+    def parse(string)
+      parser.new(string).parse
+    end
 
-  # # foo:
-  # "foo:", [1, 2]
-  def handle_label(label, lineno_column)
-    Literal.new label[0..-2].to_sym
   end
 
 end

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -43,6 +43,9 @@ class Solid::Parser
       :'and' => ->(left, right) { left and right },
       :'or' => ->(left, right) { left or right }
     }
+    BUILTIN_HANDLERS.keys.each do |operator|
+      BUILTIN_HANDLERS[operator.to_s] = BUILTIN_HANDLERS[operator]
+    end
 
     def evaluate(context)
       Solid.to_liquid(pluck(receiver.evaluate(context), name, *arguments.map {|arg| arg.evaluate(context) }), context)

--- a/lib/solid/parser.rb
+++ b/lib/solid/parser.rb
@@ -3,6 +3,7 @@ class Solid::Parser
   BASE_PATH = File.join(File.expand_path(File.dirname(__FILE__)), 'parser')
 
   autoload :Ripper, File.join(BASE_PATH, 'ripper')
+  autoload :RubyParser, File.join(BASE_PATH, 'ruby_parser')
 
   class ContextVariable < Struct.new(:name)
     def evaluate(context)
@@ -72,11 +73,11 @@ class Solid::Parser
     attr_writer :parser
 
     def parser
-      @parser || Solid::Parser::Ripper
+      @parser || Solid::Parser::RubyParser
     end
 
     def parse(string)
-      parser.new(string).parse
+      parser.parse(string)
     end
 
   end

--- a/lib/solid/parser/ripper.rb
+++ b/lib/solid/parser/ripper.rb
@@ -2,6 +2,10 @@ require 'ripper'
 
 class Solid::Parser::Ripper < Solid::Parser
 
+  def self.parse(string)
+    new(string).parse
+  end
+
   def initialize(string)
     @string = string
     @sexp = nil

--- a/lib/solid/parser/ripper.rb
+++ b/lib/solid/parser/ripper.rb
@@ -1,5 +1,3 @@
-require 'ripper'
-
 class Solid::Parser::Ripper < Solid::Parser
 
   def self.parse(string)

--- a/lib/solid/parser/ripper.rb
+++ b/lib/solid/parser/ripper.rb
@@ -152,11 +152,30 @@ class Solid::Parser::Ripper < Solid::Parser
     string_content
   end
 
+  REGEXP_FLAGS = {
+    'i' => Regexp::IGNORECASE,
+    'x' => Regexp::EXTENDED,
+    'm' => Regexp::MULTILINE,
+    'n' => Regexp::NOENCODING
+  }
+
+  def instanciate_regexp(content, flags)
+    mode = 0
+    flags.each_char do |flag|
+      mode |= REGEXP_FLAGS[flag] || 0
+    end
+    Regexp.new(content, mode)
+  end
+
   # # /bb|[^b]{2}/
-  # [[:@tstring_content, "bb|[^b]{2}", [1, 2]]].first.first
+  # [[[:@tstring_content, "bb|[^b]{2}", [1, 1]]], [:@regexp_end, "/", [1, 4]]]
+
+  # # /bb|[^b]{2}/ix
+  # [[[:@tstring_content, "bb|[^b]{2}", [1, 1]]], [:@regexp_end, "/ix", [1, 4]]]
+
   # TODO: handle regexp interpolation
-  def handle_regexp_literal(regexp_literal, lineno_column)
-    Literal.new Regexp.new(regexp_literal.first[1])
+  def handle_regexp_literal(regexp_content, regexp_end)
+    Literal.new instanciate_regexp(regexp_content.first[1], regexp_end[1][1..-1])
   end
 
   # # true

--- a/lib/solid/parser/ripper.rb
+++ b/lib/solid/parser/ripper.rb
@@ -1,0 +1,194 @@
+require 'ripper'
+
+class Solid::Parser::Ripper < Solid::Parser
+
+  def initialize(string)
+    @string = string
+    @sexp = nil
+  end
+
+  def parse
+    @sexp = ::Ripper.sexp(@string)
+    dive_in or raise 'Ripper changed?'
+    parse_one(@sexp)
+  end
+
+  # Looks for a structure like
+  # [:program, [[:array, [#stuff#]]]] or
+  # [:program, [[:array, nil]]]
+  def dive_in
+    @sexp = @sexp[1]
+    @sexp = @sexp.first
+  end
+
+  def parse_one(argument)
+    type = argument.shift
+    handler = "handle_#{type.to_s.sub('@', '')}"
+    raise Solid::SyntaxError, "unknown Ripper type: #{type.inspect}" unless respond_to?(handler)
+    public_send handler, *argument
+  end
+
+  # # spam
+  # [:@ident, "spam", [1, 33]] or
+  # # true
+  # [:@kw, "true", [1, 23]]
+  def handle_var_ref(var_ref)
+    parse_one(var_ref)
+  end
+
+  # # foo: 42
+  # [[:assoc_new, [:@label, "foo:", [1, 1]], [:@int, "42", [1, 5]]]]
+  def handle_bare_assoc_hash(assoc_hash)
+    LiteralHash.new assoc_hash.map {|(_, *key_value)| key_value.map(&method(:parse_one)) }
+  end
+
+  # # {foo: 42}
+  # [:assoclist_from_args, [[:assoc_new, [:@label, "foo:", [1, 2]], [:@int, "42", [1, 7]]]]]
+  def handle_hash(hash)
+    handle_bare_assoc_hash(hash.last)
+  end
+
+  # # myvar.length
+  #
+  # [:var_ref, [:@ident, "myvar", [1, 1]]]
+  # :"."
+  # [:@ident, "length", [1, 7]]
+  def handle_call(receiver_sexp, method_call, method_sexp)
+    receiver = parse_one(receiver_sexp)
+    method = method_sexp[1]
+    MethodCall.new receiver, method, []
+  end
+
+  # # myvar
+  #
+  # since 1.9.3
+  # [:vcall, [:@ident, "myvar", [1, 0]]]
+  def handle_vcall(expression)
+    parse_one(expression)
+  end
+
+  # # myvar.split(',', 2)
+  #
+  # [:call, [:var_ref, [:@ident, "myvar", [1, 1]]], :".", [:@ident, "split", [1, 7]]]
+  # [:arg_paren, [:args_add_block, [
+  #     [:string_literal, [:string_content, [:@tstring_content, ",", [1, 14]]]],
+  #     [:@int, "2", [1, 18]]
+  #   ], false]]
+  def handle_method_add_arg(call_sexp, args_sexp)
+    method_call = parse_one(call_sexp)
+    method_call.arguments = method_call_args(args_sexp)
+    method_call
+  end
+
+  # # args list: (',', 2)
+  # [:arg_paren, [:args_add_block, [
+  #     [:string_literal, [:string_content, [:@tstring_content, ",", [1, 14]]]],
+  #     [:@int, "2", [1, 18]]
+  #   ], false]]
+  #
+  # 1 args list: ()
+  # [:arg_paren, nil]
+  def method_call_args(args_sexp)
+    return [] if args_sexp[1].nil?
+    args_sexp = args_sexp.last[1]
+    args_sexp.map(&method(:parse_one))
+  end
+
+  # # !true
+  # [:!, [:var_ref, [:@kw, "true", [1, 1]]]]
+  def handle_unary(operator, operand)
+    MethodCall.new(parse_one(operand), operator, [])
+  end
+
+  # # 1 + 2
+  # [:@int, "1", [1, 0]], :*, [:@int, "2", [1, 4]]
+  def handle_binary(left_operand, operator, right_operand)
+    receiver = parse_one(left_operand)
+    MethodCall.new(receiver, operator, [parse_one(right_operand)])
+  end
+
+  # # [1]
+  # [[:@int, "1", [1, 1]]
+  def handle_array(array)
+    LiteralArray.new((array || []).map(&method(:parse_one)))
+  end
+
+  # # (1)
+  # [[:@int, "42", [1, 2]]]
+  def handle_paren(content)
+    parse_one(content.first)
+  end
+
+  # # 1..10
+  # [[:@int, "1", [1, 0]], [:@int, "10", [1, 4]]]
+  def handle_dot2(start_value, end_value)
+    LiteralRange.new(parse_one(start_value), parse_one(end_value), false)
+  end
+
+  # # 1...10
+  # [[:@int, "1", [1, 0]], [:@int, "10", [1, 4]]]
+  def handle_dot3(start_value, end_value)
+    LiteralRange.new(parse_one(start_value), parse_one(end_value), true)
+  end
+
+  # # 'mystring'
+  # [:string_content, [:@tstring_content, "mystring", [1, 14]]]
+  # TODO: handle string interpolation
+  def handle_string_literal(string_content)
+    Literal.new(parse_one(string_content))
+  end
+
+  def handle_string_content(*parts)
+    parts.map(&method(:parse_one)).join
+  end
+
+  # [:@tstring_content, "mystring", [1, 14]]
+  def handle_tstring_content(string_content, lineno_column)
+    string_content
+  end
+
+  # # /bb|[^b]{2}/
+  # [[:@tstring_content, "bb|[^b]{2}", [1, 2]]].first.first
+  # TODO: handle regexp interpolation
+  def handle_regexp_literal(regexp_literal, lineno_column)
+    Literal.new Regexp.new(regexp_literal.first[1])
+  end
+
+  # # true
+  # "true", [1, 33]
+  def handle_kw(keyword, lineno_column)
+    raise Solid::SyntaxError, 'unknown Ripper sexp' unless KEYWORDS.has_key? keyword
+    KEYWORDS[keyword]
+  end
+
+  # # spam
+  # "spam", [1, 23]
+  def handle_ident(identifier, lineno_column)
+    ContextVariable.new identifier
+  end
+
+  # # Spam
+  # "Spam", [1, 23]
+  def handle_const(constant, lineno_column)
+    ContextVariable.new constant
+  end
+
+  # # 42
+  # "42", [1, 2]
+  def handle_int(int, lineno_column)
+    Literal.new int.to_i
+  end
+
+  # # 4.2
+  # "4.2", [1, 2]
+  def handle_float(float, lineno_column)
+    Literal.new float.to_f
+  end
+
+  # # foo:
+  # "foo:", [1, 2]
+  def handle_label(label, lineno_column)
+    Literal.new label[0..-2].to_sym
+  end
+
+end

--- a/lib/solid/parser/ripper.rb
+++ b/lib/solid/parser/ripper.rb
@@ -49,6 +49,7 @@ class Solid::Parser::Ripper < Solid::Parser
   # # {foo: 42}
   # [:assoclist_from_args, [[:assoc_new, [:@label, "foo:", [1, 2]], [:@int, "42", [1, 7]]]]]
   def handle_hash(hash)
+    return LiteralHash.new({}) unless hash
     handle_bare_assoc_hash(hash.last)
   end
 

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -24,7 +24,7 @@ class Solid::Parser::RubyParser < Solid::Parser
 
   def handle_lit(literal)
     case literal
-    when Range
+    when Range # see https://github.com/seattlerb/ruby_parser/issues/134
       LiteralRange.new(Literal.new(literal.first), Literal.new(literal.last), literal.exclude_end?)
     else
       Literal.new(literal)

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -34,4 +34,8 @@ class Solid::Parser::RubyParser < Solid::Parser
     LiteralArray.new(array_values.map(&method(:parse_one)))
   end
 
+  def handle_hash(*hash_keys_and_values)
+    LiteralHash.new(Hash[*hash_keys_and_values.map(&method(:parse_one))])
+  end
+
 end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -59,8 +59,10 @@ class Solid::Parser::RubyParser < Solid::Parser
     ContextVariable.new(const_name.to_s)
   end
 
-  def handle_call(context, method_name)
-    return ContextVariable.new(method_name.to_s) if context.nil?
+  def handle_call(receiver, method_name)
+    return ContextVariable.new(method_name.to_s) if receiver.nil?
+
+    MethodCall.new(parse_one(receiver), method_name, [])
   end
 
 end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -38,4 +38,16 @@ class Solid::Parser::RubyParser < Solid::Parser
     LiteralHash.new(Hash[*hash_keys_and_values.map(&method(:parse_one))])
   end
 
+  def handle_true
+    KEYWORDS['true']
+  end
+
+  def handle_false
+    KEYWORDS['false']
+  end
+
+  def handle_nil
+    KEYWORDS['nil']
+  end
+
 end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -43,6 +43,14 @@ class Solid::Parser::RubyParser < Solid::Parser
     LiteralHash.new(Hash[*hash_keys_and_values.map(&method(:parse_one))])
   end
 
+  def handle_dot2(start_value, end_value)
+    LiteralRange.new(parse_one(start_value), parse_one(end_value), false)
+  end
+
+  def handle_dot3(start_value, end_value)
+    LiteralRange.new(parse_one(start_value), parse_one(end_value), true)
+  end
+
   def handle_true
     KEYWORDS['true']
   end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -23,7 +23,12 @@ class Solid::Parser::RubyParser < Solid::Parser
   end
 
   def handle_lit(literal)
-    Literal.new(literal)
+    case literal
+    when Range
+      LiteralRange.new(Literal.new(literal.first), Literal.new(literal.last), literal.exclude_end?)
+    else
+      Literal.new(literal)
+    end
   end
 
   def handle_str(literal)

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -64,5 +64,4 @@ class Solid::Parser::RubyParser < Solid::Parser
 
     MethodCall.new(parse_one(receiver), method_name, arguments.map(&method(:parse_one)))
   end
-
 end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -1,0 +1,37 @@
+require 'ruby_parser'
+
+class Solid::Parser::RubyParser < Solid::Parser
+
+  def self.parse(string)
+    new(string).parse
+  end
+
+  def initialize(expression)
+    @expression = expression
+  end
+
+  def parse
+    @sexp = ::RubyParser.new.parse(@expression)
+    parse_one(@sexp)
+  end
+
+  def parse_one(expression)
+    type = expression.shift
+    handler = "handle_#{type}"
+    raise Solid::SyntaxError, "unknown expression type: #{type.inspect}" unless respond_to?(handler)
+    public_send handler, *expression
+  end
+
+  def handle_lit(literal)
+    Literal.new(literal)
+  end
+
+  def handle_str(literal)
+    Literal.new(literal)
+  end
+
+  def handle_array(*array_values)
+    LiteralArray.new(array_values.map(&method(:parse_one)))
+  end
+
+end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -11,7 +11,11 @@ class Solid::Parser::RubyParser < Solid::Parser
   end
 
   def parse
-    @sexp = ::RubyParser.new.parse(@expression)
+    begin
+      @sexp = ::RubyParser.new.parse(@expression)
+    rescue ::RubyParser::SyntaxError => exc
+      raise Solid::SyntaxError.new(exc.message)
+    end
     parse_one(@sexp)
   end
 
@@ -70,7 +74,7 @@ class Solid::Parser::RubyParser < Solid::Parser
   def handle_call(receiver, method_name, *arguments)
     return ContextVariable.new(method_name.to_s) if receiver.nil?
 
-    MethodCall.new(parse_one(receiver), method_name, arguments.map(&method(:parse_one)))
+    MethodCall.new(parse_one(receiver), method_name.to_s, arguments.map(&method(:parse_one)))
   end
 
   def handle_and(left_expression, right_expression)

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -55,4 +55,12 @@ class Solid::Parser::RubyParser < Solid::Parser
     KEYWORDS['nil']
   end
 
+  def handle_const(const_name)
+    ContextVariable.new(const_name.to_s)
+  end
+
+  def handle_call(context, method_name)
+    return ContextVariable.new(method_name.to_s) if context.nil?
+  end
+
 end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -72,4 +72,13 @@ class Solid::Parser::RubyParser < Solid::Parser
 
     MethodCall.new(parse_one(receiver), method_name, arguments.map(&method(:parse_one)))
   end
+
+  def handle_and(left_expression, right_expression)
+    handle_call(left_expression, :'&&', right_expression)
+  end
+
+  def handle_or(left_expression, right_expression)
+    handle_call(left_expression, :'||', right_expression)
+  end
+
 end

--- a/lib/solid/parser/ruby_parser.rb
+++ b/lib/solid/parser/ruby_parser.rb
@@ -59,10 +59,10 @@ class Solid::Parser::RubyParser < Solid::Parser
     ContextVariable.new(const_name.to_s)
   end
 
-  def handle_call(receiver, method_name)
+  def handle_call(receiver, method_name, *arguments)
     return ContextVariable.new(method_name.to_s) if receiver.nil?
 
-    MethodCall.new(parse_one(receiver), method_name, [])
+    MethodCall.new(parse_one(receiver), method_name, arguments.map(&method(:parse_one)))
   end
 
 end

--- a/solid.gemspec
+++ b/solid.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "i18n"
+  s.add_development_dependency "ruby_parser"
   s.add_development_dependency "activesupport", ">= 3"
+  s.add_development_dependency "debugger"
   s.add_runtime_dependency "liquid"
 end

--- a/solid.gemspec
+++ b/solid.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "i18n"
   s.add_development_dependency "ruby_parser"
   s.add_development_dependency "activesupport", ">= 3"
-  s.add_development_dependency "debugger"
   s.add_runtime_dependency "liquid"
 end

--- a/solid.gemspec
+++ b/solid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "i18n"
-  s.add_development_dependency "ruby_parser"
+  s.add_development_dependency "ruby_parser", "~> 3.2"
   s.add_development_dependency "activesupport", ">= 3"
   s.add_runtime_dependency "liquid"
 end

--- a/spec/solid/arguments_spec.rb
+++ b/spec/solid/arguments_spec.rb
@@ -254,7 +254,7 @@ describe Solid::Arguments do
 
     it "should raise a Solid::SyntaxError on unknown constructs" do
       expect {
-        parse('{}[]')
+        parse('{}\[]')
       }.to raise_error(Solid::SyntaxError)
     end
 

--- a/spec/solid/parser/ripper_spec.rb
+++ b/spec/solid/parser/ripper_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
+ripper_support = true
+begin
+  require 'ripper'
+rescue LoadError
+  ripper_support = false
+end
+
 describe Solid::Parser::Ripper do
 
   it_should_behave_like 'a solid parser'
 
-end
+end if ripper_support

--- a/spec/solid/parser/ripper_spec.rb
+++ b/spec/solid/parser/ripper_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Solid::Parser::Ripper do
+
+  it_should_behave_like 'a solid parser'
+
+end

--- a/spec/solid/parser/ruby_parser_spec.rb
+++ b/spec/solid/parser/ruby_parser_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Solid::Parser::RubyParser do
+
+  it_should_behave_like 'a solid parser'
+
+end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -20,6 +20,12 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to 42
     end
 
+    it 'is able to parse a Float' do
+      exp = parser.parse('4.2')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to 4.2
+    end
+
     it 'is able to parse a String' do
       exp = parser.parse('"foo"')
       exp.should be_a Solid::Parser::Literal
@@ -54,6 +60,18 @@ shared_examples 'a solid parser' do
       exp = parser.parse('1...10')
       exp.should be_a Solid::Parser::LiteralRange
       exp.should evaluate_to 1...10
+    end
+
+    it 'is able to parse a inclusive Range of Float' do
+      exp = parser.parse('1.0..10.0')
+      exp.should be_a Solid::Parser::LiteralRange
+      exp.should evaluate_to 1.0..10.0
+    end
+
+    it 'is able to parse a exclusive Range of Float' do
+      exp = parser.parse('1.0...10.0')
+      exp.should be_a Solid::Parser::LiteralRange
+      exp.should evaluate_to 1.0...10.0
     end
 
     it 'is able to parse a Hash' do

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -68,6 +68,24 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to(/foo/x)
     end
 
+    it 'is able to parse a true Boolean' do
+      exp = parser.parse('true')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to(true)
+    end
+
+    it 'is able to parse a false Boolean' do
+      exp = parser.parse('false')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to(false)
+    end
+
+    it 'is able to parse a nil' do
+      exp = parser.parse('nil')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to(nil)
+    end
+
   end
 
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -1,0 +1,49 @@
+RSpec::Matchers.define :evaluate_to do |value|
+
+  match do |expression|
+    expression.evaluate(context).should be == value
+  end
+
+end
+
+shared_examples 'a solid parser' do
+
+  let(:parser) { described_class }
+
+  let(:context) { {} }
+
+  context 'literals parsing' do
+
+    it 'is able to parse an Integer' do
+      exp = parser.parse('42')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to 42
+    end
+
+    it 'is able to parse a String' do
+      exp = parser.parse('"foo"')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to 'foo'
+    end
+
+    it 'is able to parse a single quoted String' do
+      exp = parser.parse("'foo'")
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to 'foo'
+    end
+
+    it 'is able to parse an Array' do
+      exp = parser.parse('[1, 2, 3]')
+      exp.should be_a Solid::Parser::LiteralArray
+      exp.should evaluate_to [1, 2, 3]
+    end
+
+    it 'is able to parse an empty Array' do
+      exp = parser.parse('[]')
+      exp.should be_a Solid::Parser::LiteralArray
+      exp.should evaluate_to []
+    end
+
+  end
+
+end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -120,7 +120,23 @@ shared_examples 'a solid parser' do
 
   context 'methods calling' do
 
-    let(:context) { {'somevar' => 'foo'} }
+    class Dummy
+
+      def echo(exp)
+        exp
+      end
+
+      def [](key)
+        key
+      end
+
+      def to_liquid
+        self
+      end
+
+    end
+
+    let(:context) { {'somevar' => 'foo', 'dummy' => Dummy.new, 'truth' => 42} }
 
     it 'is able to call simple methods without arguments' do
       exp = parser.parse('somevar.length')
@@ -156,6 +172,36 @@ shared_examples 'a solid parser' do
       exp = parser.parse('somevar.gsub("f", "b")')
       exp.should be_a Solid::Parser::MethodCall
       exp.should evaluate_to('boo')
+    end
+
+    it 'is able to call a method with unenclosed terminating hash' do
+      exp = parser.parse('dummy.echo("foo" => "bar")')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to({"foo" => "bar"})
+    end
+
+    it 'is able to call "binary operator" methods' do
+      exp = parser.parse('1 + 1')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(2)
+    end
+
+    it 'is able to call `-` "unary operator" methods' do
+      exp = parser.parse('-truth')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(-42)
+    end
+
+    it 'is able to call `+` "unary operator" methods' do
+      exp = parser.parse('+truth')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(42)
+    end
+
+    it 'is able to call `~` "unary operator" methods' do
+      exp = parser.parse('~truth')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(-43)
     end
 
   end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -134,6 +134,18 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to(3)
     end
 
+    it 'is able to call a simple method ending with a "?"' do
+      exp = parser.parse('somevar.nil?')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(false)
+    end
+
+    it 'is able to call a simple method ending with a "!"' do
+      exp = parser.parse('somevar.strip!')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(nil)
+    end
+
   end
 
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -44,6 +44,18 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to []
     end
 
+    it 'is able to parse a Hash' do
+      exp = parser.parse('{1 => 2, 3 => 4}')
+      exp.should be_a Solid::Parser::LiteralHash
+      exp.should evaluate_to({1 => 2, 3 => 4})
+    end
+
+    it 'is able to parse an empty Hash' do
+      exp = parser.parse('{}')
+      exp.should be_a Solid::Parser::LiteralHash
+      exp.should evaluate_to({})
+    end
+
   end
 
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -146,6 +146,18 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to(nil)
     end
 
+    it 'is able to call a method on nil' do
+      exp = parser.parse('nil.nil?')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(true)
+    end
+
+    it 'is able to call a method with arguments' do
+      exp = parser.parse('somevar.gsub("f", "b")')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to('boo')
+    end
+
   end
 
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -224,4 +224,38 @@ shared_examples 'a solid parser' do
 
   end
 
+  context 'boolean operators' do
+
+    it 'is able to evaluate && expressions' do
+      exp = parser.parse('true && true')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(true)
+    end
+
+    it 'is able to evaluate || expressions' do
+      exp = parser.parse('true || false')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(true)
+    end
+
+    it 'is able to evaluate `and` expressions' do
+      exp = parser.parse('true or true')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(true)
+    end
+
+    it 'is able to evaluate `or` expressions' do
+      exp = parser.parse('true or false')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(true)
+    end
+
+    it 'is able to evaluate `!` expressions' do
+      exp = parser.parse('!false')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(true)
+    end
+
+  end
+
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -56,6 +56,18 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to({})
     end
 
+    it 'is able to parse a simple Regex' do
+      exp = parser.parse('/foo/')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to(/foo/)
+    end
+
+    it 'is able to parse a flagged Regex' do
+      exp = parser.parse('/foo/x')
+      exp.should be_a Solid::Parser::Literal
+      exp.should evaluate_to(/foo/x)
+    end
+
   end
 
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -117,4 +117,23 @@ shared_examples 'a solid parser' do
     end
 
   end
+
+  context 'methods calling' do
+
+    let(:context) { {'somevar' => 'foo'} }
+
+    it 'is able to call simple methods without arguments' do
+      exp = parser.parse('somevar.length')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(3)
+    end
+
+    it 'is able to call a method on a literal' do
+      exp = parser.parse('"foo".length')
+      exp.should be_a Solid::Parser::MethodCall
+      exp.should evaluate_to(3)
+    end
+
+  end
+
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -100,4 +100,21 @@ shared_examples 'a solid parser' do
 
   end
 
+  context 'constants and variable reference' do
+
+    let(:context) { {'TRUTH' => 42, 'somevar' => 'foo'} }
+
+    it 'is able to reference a simple constant' do
+      exp = parser.parse('TRUTH')
+      exp.should be_a Solid::Parser::ContextVariable
+      exp.should evaluate_to(42)
+    end
+
+    it 'is able to reference a simple variable' do
+      exp = parser.parse('somevar')
+      exp.should be_a Solid::Parser::ContextVariable
+      exp.should evaluate_to('foo')
+    end
+
+  end
 end

--- a/spec/support/parser_examples.rb
+++ b/spec/support/parser_examples.rb
@@ -44,6 +44,18 @@ shared_examples 'a solid parser' do
       exp.should evaluate_to []
     end
 
+    it 'is able to parse a inclusive Range' do
+      exp = parser.parse('1..10')
+      exp.should be_a Solid::Parser::LiteralRange
+      exp.should evaluate_to 1..10
+    end
+
+    it 'is able to parse a exclusive Range' do
+      exp = parser.parse('1...10')
+      exp.should be_a Solid::Parser::LiteralRange
+      exp.should evaluate_to 1...10
+    end
+
     it 'is able to parse a Hash' do
       exp = parser.parse('{1 => 2, 3 => 4}')
       exp.should be_a Solid::Parser::LiteralHash


### PR DESCRIPTION
Now multiple parser implementations are supported. The builtin implementations are `Solid::Parser::Ripper` and `Solid::Parser::RubyParser`, the default being `Solid::Parser::RubyParser`, but you can chose the implementation you want with `Solid::Parser.parser = Solid::Parser::Ripper`.

And anybody can implement his own, or subclass an existing one to limit the allowed constructs / syntaxes.

Both parsers are now tested by the same shared examples to assert some kind of compatibility.

Relying on `ruby_parser` instead of `ripper` should allow to target jRuby and Rubinius.
For now the security model do not work on Rubinius, it seems that some methods are not owned by the same classes.
And jRuby seems to have some troubles with syntaxes like `map(&method(:foo))` ...

It's also better than relying on an undocumented internal API.

Regards,

@etiennebarrie: I think `Solid::Parser::RubyParser` has the same amount of support than `Solid::Parser::Ripper`, at least all specs pass, but it would be great if you could test it on real world templates.
